### PR TITLE
Support for scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ctrl-c
 ```
 
 By default the example configurations in tomcat4ibis will be used. To use
-another project create a build.properties with the following content:
+another project create a build.properties in the main directory with the following content:
 
 ```
 project.dir=Ibis4Example
@@ -134,3 +134,20 @@ lib.webapp.dir=lib/webapp
 All jars added to lib/server are copied to the Tomcat lib folder. All jars added
 to lib/webapp are copied to the WEB-INF/lib containing the Ibis Adapter
 Framework jar files and dependencies.
+
+# Scripting
+
+You can call tomcat4ibis from a script. Any parameter to tomcat4ibis are passed to
+Ant. For instance, to create an with a specific ibis version (7.2 in the example), 
+the following call can be made:
+
+```
+tomcat4ibis -Dibis.version=7.2
+```
+
+This will create the instance, deploy on tomcat, start tomcat and return to the script.
+To shutdown the tomcat server, call shutdown:
+
+```
+shutdown
+```

--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ Framework jar files and dependencies.
 # Scripting
 
 You can call tomcat4ibis from a script. Any parameter to tomcat4ibis are passed to
-Ant. For instance, to create an with a specific ibis version (7.2 in the example), 
-the following call can be made:
+Ant and Tomcat. For instance, to create an instance with a specific ibis version 
+(7.2 in the example), logging to a specific log directory, the following call can be made:
 
 ```
-tomcat4ibis -Dibis.version=7.2
+tomcat4ibis -Dibis.version=7.2 -Dlog.dir=logs/7.2
 ```
 
 This will create the instance, deploy on tomcat, start tomcat and return to the script.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Framework jar files and dependencies.
 
 # Scripting
 
-You can call tomcat4ibis from a script. Any parameter to tomcat4ibis are passed to
+You can call tomcat4ibis from a script. Any parameter to tomcat4ibis is passed to
 Ant and Tomcat. For instance, to create an instance with a specific ibis version 
 (7.2 in the example), logging to a specific log directory, the following call can be made:
 

--- a/build.xml
+++ b/build.xml
@@ -1,10 +1,10 @@
 <project default="build.tomcat4ibis" xmlns:if="ant:if" xmlns:unless="ant:unless">
 
 	<property file="build.properties"/>
-
+	
 	<property name="projects.dir" value=".."/>
 	<property name="project.dir" value="tomcat4ibis"/>
-
+	
 	<property file="${projects.dir}/${project.dir}/tomcat4ibis.properties"/>
 
 	<available property="pom.xml.available" file="${projects.dir}/${project.dir}/pom.xml"/>
@@ -120,7 +120,7 @@ if not exist "%~dp0${jdk.dir.windows}\" (
 		if errorlevel 1 (
 			pause
 		) else (
-			call %~dp0build\sub.bat
+			call %~dp0build\sub.bat %*
 		)
 	)
 )
@@ -129,7 +129,7 @@ if not exist "%~dp0${jdk.dir.windows}\" (
 		<!-- tomcat4ibis.bat doesn't contain user specific data and can be committed to git whereas sub.bat may contain user specific data -->
 		<echo file="build/sub.bat">@echo off
 set CATALINA_HOME=%~dp0../${tomcat.dir.windows}
-set JAVA_OPTS=-Xmx1024M -Dotap.stage=LOC -Dconfigurations.directory=${projects.dir}/${project.dir}/${configurations.dir} -Dscenariosroot1.directory=../../../../../../${project.dir}/${tests.dir} -Dscenariosroot1.description=Tomcat4Ibis
+set JAVA_OPTS=-Xmx1024M -Dotap.stage=LOC -Dconfigurations.directory=${projects.dir}/${project.dir}/${configurations.dir} -Dscenariosroot1.directory=../../../../../../${project.dir}/${tests.dir} -Dscenariosroot1.description=Tomcat4Ibis %*
 %~dp0../${tomcat.dir.windows}\bin\catalina.bat start
 	)
 )

--- a/build.xml
+++ b/build.xml
@@ -1,10 +1,10 @@
 <project default="build.tomcat4ibis" xmlns:if="ant:if" xmlns:unless="ant:unless">
 
 	<property file="build.properties"/>
-	
+
 	<property name="projects.dir" value=".."/>
 	<property name="project.dir" value="tomcat4ibis"/>
-	
+
 	<property file="${projects.dir}/${project.dir}/tomcat4ibis.properties"/>
 
 	<available property="pom.xml.available" file="${projects.dir}/${project.dir}/pom.xml"/>

--- a/build.xml
+++ b/build.xml
@@ -115,13 +115,12 @@ if not exist "%~dp0${jdk.dir.windows}\" (
 		echo Please download ${ant.url} and unzip it in %~dp0build\
 		pause
 	) else (
-		set JAVA_HOME=${jdk.dir.windows}
-		cd %~dp0
-		${ant.dir.windows}\bin\ant
+		set JAVA_HOME=%~dp0${jdk.dir.windows}
+		%~dp0${ant.dir.windows}\bin\ant -buildfile %~dp0build.xml -Dprojects.dir=%~dp0.. %*
 		if errorlevel 1 (
 			pause
 		) else (
-			build\sub.bat
+			call %~dp0build\sub.bat
 		)
 	)
 )
@@ -129,11 +128,15 @@ if not exist "%~dp0${jdk.dir.windows}\" (
 		<!-- tomcat4ibis.bat will call sub.bat just after it called ant to generate it (this will make sure sub.bat reflects the latest changes) -->
 		<!-- tomcat4ibis.bat doesn't contain user specific data and can be committed to git whereas sub.bat may contain user specific data -->
 		<echo file="build/sub.bat">@echo off
-set CATALINA_HOME=${tomcat.dir.windows}
-set JAVA_OPTS=-Xmx1024M -Dotap.stage=LOC -Dconfigurations.directory=${projects.dir}/${project.dir}/${configurations.dir} -Dscenariosroot1.directory=../../../../../${projects.dir}/${project.dir}/${tests.dir} -Dscenariosroot1.description=Tomcat4Ibis
-${tomcat.dir.windows}\bin\catalina.bat run
+set CATALINA_HOME=%~dp0../${tomcat.dir.windows}
+set JAVA_OPTS=-Xmx1024M -Dotap.stage=LOC -Dconfigurations.directory=${projects.dir}/${project.dir}/${configurations.dir} -Dscenariosroot1.directory=../../../../../../${project.dir}/${tests.dir} -Dscenariosroot1.description=Tomcat4Ibis
+%~dp0../${tomcat.dir.windows}\bin\catalina.bat start
 	)
 )
+		</echo>
+		<!-- shutdown.bat can be called from a script to stop tomcat -->
+		<echo file="shutdown.bat">@echo off
+call %~dp0${tomcat.dir.windows}\bin\catalina.bat stop
 		</echo>
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 
 	<property file="build.properties"/>
 
-	<property name="projects.dir" value=".."/>
+	<property name="projects.dir" value="${basedir}/.."/>
 	<property name="project.dir" value="tomcat4ibis"/>
 
 	<property file="${projects.dir}/${project.dir}/tomcat4ibis.properties"/>
@@ -116,7 +116,7 @@ if not exist "%~dp0${jdk.dir.windows}\" (
 		pause
 	) else (
 		set JAVA_HOME=%~dp0${jdk.dir.windows}
-		%~dp0${ant.dir.windows}\bin\ant -buildfile %~dp0build.xml -Dprojects.dir=%~dp0.. %*
+		%~dp0${ant.dir.windows}\bin\ant -buildfile %~dp0build.xml %*
 		if errorlevel 1 (
 			pause
 		) else (

--- a/shutdown.bat
+++ b/shutdown.bat
@@ -1,0 +1,3 @@
+@echo off
+call %~dp0build\apache-tomcat-7.0.96\bin\catalina.bat stop
+		

--- a/tomcat4ibis.bat
+++ b/tomcat4ibis.bat
@@ -13,7 +13,7 @@ if not exist "%~dp0build\openjdk-8u232-b09\" (
 		if errorlevel 1 (
 			pause
 		) else (
-			call %~dp0build\sub.bat
+			call %~dp0build\sub.bat %*
 		)
 	)
 )

--- a/tomcat4ibis.bat
+++ b/tomcat4ibis.bat
@@ -9,7 +9,7 @@ if not exist "%~dp0build\openjdk-8u232-b09\" (
 		pause
 	) else (
 		set JAVA_HOME=%~dp0build\openjdk-8u232-b09
-		%~dp0build\apache-ant-1.10.7\bin\ant -buildfile %~dp0build.xml -Dprojects.dir=%~dp0.. %*
+		%~dp0build\apache-ant-1.10.7\bin\ant -buildfile %~dp0build.xml %*
 		if errorlevel 1 (
 			pause
 		) else (

--- a/tomcat4ibis.bat
+++ b/tomcat4ibis.bat
@@ -8,13 +8,12 @@ if not exist "%~dp0build\openjdk-8u232-b09\" (
 		echo Please download http://apache.redkiwi.nl//ant/binaries/apache-ant-1.10.7-bin.zip and unzip it in %~dp0build\
 		pause
 	) else (
-		set JAVA_HOME=build\openjdk-8u232-b09
-		cd %~dp0
-		build\apache-ant-1.10.7\bin\ant
+		set JAVA_HOME=%~dp0build\openjdk-8u232-b09
+		%~dp0build\apache-ant-1.10.7\bin\ant -buildfile %~dp0build.xml -Dprojects.dir=%~dp0.. %*
 		if errorlevel 1 (
 			pause
 		) else (
-			build\sub.bat
+			call %~dp0build\sub.bat
 		)
 	)
 )


### PR DESCRIPTION
- Allow to call tomcat4ibis from a different folder, without changing
the default folder;
- Allow to pass parameters to Ant via the command line of tomcat4ibis
- add shutdown script

N.B. internal handling of directories project.dir and tomcat.dir might
need to be looked after / revised. In the generated scripts they are
now prefixed with the path of tomcat4ibis.